### PR TITLE
initialize IGC_B_Record::$extension_offsets with empty array()

### DIFF
--- a/lib/IGC_B_Record.php
+++ b/lib/IGC_B_Record.php
@@ -75,7 +75,7 @@ class IGC_B_Record extends IGC_Record
    * @access private
    * @var array
    */
-  private static $extension_offsets;
+  private static $extension_offsets = array();
 
   /**
    * Class constructor creates the B record from the raw IGC string


### PR DESCRIPTION
Avoid "PHP Warning:  Invalid argument supplied for foreach()"
in lib/IGC_B_Record.php:126
